### PR TITLE
Add on/off state for siren/strobe driver

### DIFF
--- a/drivers/konnected-siren-strobe.groovy
+++ b/drivers/konnected-siren-strobe.groovy
@@ -47,11 +47,13 @@ def updatePinState(Integer state) {
 def off() {
   def val = invertTrigger ? 1 : 0
   parent.deviceUpdateDeviceState(device.deviceNetworkId, val)
+  sendEvent(name: "switch", value: "off", displayed: true)
 }
 
 def on() {
   def val = invertTrigger ? 0 : 1
   parent.deviceUpdateDeviceState(device.deviceNetworkId, val)
+  sendEvent(name: "switch", value: "on", displayed: true)
 }
 
 def both() { on() }


### PR DESCRIPTION
The current siren/strobe driver has the switch capability, however it does not track the state of the switch. This means the on/off events for any strobe or siren that is using this driver is unable to be subscribed to and used in any rule etc.

This PR adds the ability to send the off/on event when the on/off method is called.