### PR TITLE
Fix: reliably select main attribute from child device instead of using unordered .first()

### DIFF
--- a/drivers/konnected-alarm-panel.groovy
+++ b/drivers/konnected-alarm-panel.groovy
@@ -214,7 +214,7 @@ private void doParseState(Map message) {
 
     // Find the attribute this child supports from that list
     def supported = childDevice.getSupportedAttributes()*.name
-    String attr, value, type, unit, description
+    String matchedAttr, value, type, unit, description
 
     for (attr in supported) {
         switch (attr) {
@@ -222,45 +222,54 @@ private void doParseState(Map message) {
                 if (!message.hasState) { return }
                 value = message.state ? 'open' : 'closed'
                 description = 'Contact'
+                matchedAttr = attr
                 break
             case 'motion':
                 if (!message.hasState) { return }
                 value = message.state ? 'active' : 'inactive'
                 description = 'Motion'
+                matchedAttr = attr
                 break
             case 'smoke':
                 if (!message.hasState) { return }
                 value = message.state ? 'detected' : 'clear'
                 description = 'Smoke'
+                matchedAttr = attr
                 break
             case 'carbonMonoxide':
                 if (!message.hasState) { return }
                 value = message.state ? 'detected' : 'clear'
                 description = 'Carbon Monoxide'
+                matchedAttr = attr
                 break
             case 'sound':
                 if (!message.hasState) { return }
                 value = message.state ? 'detected' : 'not detected'
                 description = 'Sound'
+                matchedAttr = attr
                 break
             case 'switch':
                 value = message.state ? 'on' : 'off'
                 description = 'Switch'
+                matchedAttr = attr
                 break
             case 'water':
                 if (!message.hasState) { return }
                 value = message.state ? 'wet' : 'dry'
                 description = 'Moisture'
+                matchedAttr = attr
                 break
             case 'temperature':
                 value = message.state.setScale(1, RoundingMode.HALF_UP);
                 description = 'Temperature'
                 unit = state["unit-${message.key}"]
+                matchedAttr = attr
                 break
             case 'humidity':
                 value = message.state.setScale(1, RoundingMode.HALF_UP);
                 description = 'Humidity'
                 unit = state["unit-${message.key}"]
+                matchedAttr = attr
                 break
             default:
                 continue  // ignore attributes we don’t handle
@@ -269,7 +278,7 @@ private void doParseState(Map message) {
         break
     }
     if (!value) { return }
-    sendDeviceEvent(attr, value, type, unit, description, childDevice, attr)    
+    sendDeviceEvent(matchedAttr, value, type, unit, description, childDevice, matchedAttr)
   }
   
   if (state.signalStrengthKey as Long == message.key && message.hasState) {

--- a/drivers/konnected-alarm-panel.groovy
+++ b/drivers/konnected-alarm-panel.groovy
@@ -211,7 +211,17 @@ private void doParseState(Map message) {
   // update the state of a child device that matches the key
   def childDevice = getChildDevice("${device.id}-${message.key}")
   if (childDevice) {
-    String attr = childDevice.getSupportedAttributes().first()
+    // Define the list of attributes we actually care about
+    def knownAttrs = [
+        'contact', 'motion', 'smoke', 'carbonMonoxide',
+        'sound', 'switch', 'water', 'temperature', 'humidity'
+    ]
+
+    // Find the attribute this child supports from that list
+    def supported = childDevice.getSupportedAttributes()*.name
+    String attr = supported.find { it in knownAttrs }
+    if (!attr) { return }
+
     String value, type, unit, description
 
     switch (attr) {

--- a/drivers/konnected-alarm-panel.groovy
+++ b/drivers/konnected-alarm-panel.groovy
@@ -211,65 +211,62 @@ private void doParseState(Map message) {
   // update the state of a child device that matches the key
   def childDevice = getChildDevice("${device.id}-${message.key}")
   if (childDevice) {
-    // Define the list of attributes we actually care about
-    def knownAttrs = [
-        'contact', 'motion', 'smoke', 'carbonMonoxide',
-        'sound', 'switch', 'water', 'temperature', 'humidity'
-    ]
 
     // Find the attribute this child supports from that list
     def supported = childDevice.getSupportedAttributes()*.name
-    String attr = supported.find { it in knownAttrs }
-    if (!attr) { return }
+    String attr, value, type, unit, description
 
-    String value, type, unit, description
-
-    switch (attr) {
-        case 'contact':
-            if (!message.hasState) { return }
-            value = message.state ? 'open' : 'closed'
-            description = 'Contact'
-            break
-        case 'motion':
-            if (!message.hasState) { return }
-            value = message.state ? 'active' : 'inactive'
-            description = 'Motion'
-            break
-        case 'smoke':
-            if (!message.hasState) { return }
-            value = message.state ? 'detected' : 'clear'
-            description = 'Smoke'
-            break
-        case 'carbonMonoxide':
-            if (!message.hasState) { return }
-            value = message.state ? 'detected' : 'clear'
-            description = 'Carbon Monoxide'
-            break
-        case 'sound':
-            if (!message.hasState) { return }
-            value = message.state ? 'detected' : 'not detected'
-            description = 'Sound'
-            break
-        case 'switch':
-            value = message.state ? 'on' : 'off'
-            description = 'Switch'
-            break
-        case 'water':
-            if (!message.hasState) { return }
-            value = message.state ? 'wet' : 'dry'
-            description = 'Moisture'
-            break
-        case 'temperature':
-            value = message.state.setScale(1, RoundingMode.HALF_UP);
-            description = 'Temperature'
-            unit = state["unit-${message.key}"]
-            break
-        case 'humidity':
-            value = message.state.setScale(1, RoundingMode.HALF_UP);
-            description = 'Humidity'
-            unit = state["unit-${message.key}"]
-            break
-
+    for (attr in supported) {
+        switch (attr) {
+            case 'contact':
+                if (!message.hasState) { return }
+                value = message.state ? 'open' : 'closed'
+                description = 'Contact'
+                break
+            case 'motion':
+                if (!message.hasState) { return }
+                value = message.state ? 'active' : 'inactive'
+                description = 'Motion'
+                break
+            case 'smoke':
+                if (!message.hasState) { return }
+                value = message.state ? 'detected' : 'clear'
+                description = 'Smoke'
+                break
+            case 'carbonMonoxide':
+                if (!message.hasState) { return }
+                value = message.state ? 'detected' : 'clear'
+                description = 'Carbon Monoxide'
+                break
+            case 'sound':
+                if (!message.hasState) { return }
+                value = message.state ? 'detected' : 'not detected'
+                description = 'Sound'
+                break
+            case 'switch':
+                value = message.state ? 'on' : 'off'
+                description = 'Switch'
+                break
+            case 'water':
+                if (!message.hasState) { return }
+                value = message.state ? 'wet' : 'dry'
+                description = 'Moisture'
+                break
+            case 'temperature':
+                value = message.state.setScale(1, RoundingMode.HALF_UP);
+                description = 'Temperature'
+                unit = state["unit-${message.key}"]
+                break
+            case 'humidity':
+                value = message.state.setScale(1, RoundingMode.HALF_UP);
+                description = 'Humidity'
+                unit = state["unit-${message.key}"]
+                break
+            default:
+                continue  // ignore attributes we don’t handle
+        }
+        // Once we’ve found and handled one attribute, stop looping
+        break
     }
     if (!value) { return }
     sendDeviceEvent(attr, value, type, unit, description, childDevice, attr)    

--- a/package-alarm-panel.json
+++ b/package-alarm-panel.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Alarm Panel (universal)",
   "author": "Konnected Inc.",
-  "version": "1.0",
+  "version": "1.0.1",
   "minimumHEVersion": "0.0",
   "dateReleased": "2024-09-27",
   "bundles": [


### PR DESCRIPTION
This PR addresses: https://github.com/konnected-io/konnected-hubitat/issues/10

Previously, doParseState() selected a child device’s attribute using:
`childDevice.getSupportedAttributes().first()`

However, `getSupportedAttributes()` returns a `Set`, which is unordered, causing inconsistent behavior when devices supported multiple attributes (e.g., `[battery, temperature]` vs `[temperature, battery]`).
This led to incorrect event updates when the non-primary attribute (like `battery`) was chosen.
This PR updates the logic to deterministically select the correct attribute:
- Iterates over all supported attributes of the child device.
- Uses a `switch` to handle only relevant, stateful attributes: 'contact', 'motion', 'smoke', 'carbonMonoxide', 'sound', 'switch', 'water', 'temperature', 'humidity'
- Ignores unsupported attributes (like battery) automatically.
- Stops looping once the first valid attribute is matched and processed.
- Uses a `matchedAttr` variable to track the chosen attribute for the sendDeviceEvent() call, ensuring the correct attribute is always reported.

This ensures deterministic, reliable state updates across all supported device types, even when devices report multiple attributes.